### PR TITLE
Add client side certificates verification example to docs

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -505,6 +505,17 @@ pass it into the connector::
   session = aiohttp.ClientSession(connector=conn)
   r = await session.get('https://example.com')
 
+If you need to verify **client-side** certificates, you can do the same thing as the previous example,
+but add another call to ``load_cret_chain`` with the key pair::
+
+  sslcontext = ssl.create_default_context(
+     cafile='/path/to/client-side-ca-bundle.crt')
+  sslcontext.load_cert_chain('/path/to/client/public/key.pem', '/path/to/client/private/key.pem')
+  conn = aiohttp.TCPConnector(ssl_context=sslcontext)
+  session = aiohttp.ClientSession(connector=conn)
+  r = await session.get('https://server-with-client-side-certificates-validaction.com')
+
+
 You may also verify certificates via MD5, SHA1, or SHA256 fingerprint::
 
   # Attempt to connect to https://www.python.org


### PR DESCRIPTION
I've spent some time figuring this out on my own (and have written an answer to the only other guy on SO that asked himself the same question http://stackoverflow.com/questions/41701791/aiohttp-and-client-side-ssl-certificates/43664652#43664652)

Requests documentation is pretty straightforward about this http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates

I think this will be a useful example for future users of this feature (without any high-level API changes like requests implemented).